### PR TITLE
Add title screen predicate

### DIFF
--- a/src/client/kotlin/liltojustice/trueadaptivemusic/client/predicate/TitleScreenPredicate.kt
+++ b/src/client/kotlin/liltojustice/trueadaptivemusic/client/predicate/TitleScreenPredicate.kt
@@ -2,13 +2,12 @@ package liltojustice.trueadaptivemusic.client.predicate
 
 import com.google.gson.JsonObject
 import net.minecraft.client.MinecraftClient
-import net.minecraft.client.gui.screen.TitleScreen
 
 class TitleScreenPredicate(partialPath: String)
     : MusicPredicate(partialPath) {
 
     override fun test(client: MinecraftClient): Boolean {
-        return client.currentScreen is TitleScreen
+        return client.world == null;
     }
 
     override fun getIDs(): List<String> { return emptyList() }  // return immutable list, won't be using this

--- a/src/client/kotlin/liltojustice/trueadaptivemusic/client/predicate/TitleScreenPredicate.kt
+++ b/src/client/kotlin/liltojustice/trueadaptivemusic/client/predicate/TitleScreenPredicate.kt
@@ -1,0 +1,23 @@
+package liltojustice.trueadaptivemusic.client.predicate
+
+import com.google.gson.JsonObject
+import net.minecraft.client.MinecraftClient
+import net.minecraft.client.gui.screen.TitleScreen
+
+class TitleScreenPredicate(partialPath: String)
+    : MusicPredicate(partialPath) {
+
+    override fun test(client: MinecraftClient): Boolean {
+        return client.currentScreen is TitleScreen
+    }
+
+    override fun getIDs(): List<String> { return emptyList() }  // return immutable list, won't be using this
+
+    companion object: MusicPredicateCompanion<TitleScreenPredicate> {
+        override fun getTypeName(): String { return "title_screen" }
+
+        override fun fromJson(json: JsonObject, partialPath: String): TitleScreenPredicate {
+            return TitleScreenPredicate(partialPath)
+        }
+    }
+}


### PR DESCRIPTION
Plays configured music if player is not in a world (i.e., in the title screen or corresponding menu screens).